### PR TITLE
Add command to enter the directory path for the newly imported project

### DIFF
--- a/core/agents/importer.py
+++ b/core/agents/importer.py
@@ -35,8 +35,10 @@ class Importer(BaseAgent):
             f"This is an experimental feature and is currently limited to projects with size up to {MAX_PROJECT_LINES} lines of code."
         )
 
+        directory_path = await self.prompt_for_directory_path()
+
         await self.ask_question(
-            f"Please copy your project files to {project_root} and press Continue",
+            f"Please copy your project files to {directory_path} and press Continue",
             allow_empty=False,
             buttons={
                 "continue": "Continue",
@@ -52,6 +54,13 @@ class Importer(BaseAgent):
                 f"WARNING: Your project ({imported_lines} LOC) is larger than supported and may cause issues in Pythagora."
             )
         await self.state_manager.commit()
+
+    async def prompt_for_directory_path(self) -> str:
+        user_input = await self.ask_question(
+            "Please enter the directory path for the newly imported project:",
+            allow_empty=False,
+        )
+        return user_input.text
 
     async def analyze_project(self):
         llm = self.get_llm()

--- a/core/cli/helpers.py
+++ b/core/cli/helpers.py
@@ -96,6 +96,7 @@ def parse_arguments() -> Namespace:
         --email: User's email address, if provided
         --extension-version: Version of the VSCode extension, if used
         --no-check: Disable initial LLM API check
+        --directory-path: Directory path for the newly imported project
     :return: Parsed arguments object.
     """
     version = get_version()
@@ -136,6 +137,7 @@ def parse_arguments() -> Namespace:
     parser.add_argument("--email", help="User's email address", required=False)
     parser.add_argument("--extension-version", help="Version of the VSCode extension", required=False)
     parser.add_argument("--no-check", help="Disable initial LLM API check", action="store_true")
+    parser.add_argument("--directory-path", help="Directory path for the newly imported project", required=False)
     return parser.parse_args()
 
 
@@ -178,6 +180,9 @@ def load_config(args: Namespace) -> Optional[Config]:
             if provider not in config.llm:
                 config.llm[provider] = ProviderConfig()
             config.llm[provider].api_key = key
+
+    if args.directory_path:
+        config.directory_path = args.directory_path
 
     try:
         Config.model_validate(config)

--- a/core/cli/main.py
+++ b/core/cli/main.py
@@ -163,6 +163,9 @@ async def run_pythagora_session(sm: StateManager, ui: UIBase, args: Namespace):
         if not success:
             return False
 
+    if args.directory_path:
+        sm.config.directory_path = args.directory_path
+
     return await run_project(sm, ui)
 
 

--- a/core/ui/base.py
+++ b/core/ui/base.py
@@ -304,6 +304,18 @@ class UIBase:
         """
         raise NotImplementedError()
 
+    async def prompt_for_directory_path(self) -> str:
+        """
+        Prompt the user to enter the directory path for the newly imported project.
+
+        :return: Directory path entered by the user.
+        """
+        user_input = await self.ask_question(
+            "Please enter the directory path for the newly imported project:",
+            allow_empty=False,
+        )
+        return user_input.text
+
 
 pythagora_source = UISource("Pythagora", "pythagora")
 success_source = UISource("Congratulations", "success")

--- a/core/ui/ipc_client.py
+++ b/core/ui/ipc_client.py
@@ -369,5 +369,12 @@ class IPCClientUI(UIBase):
     async def import_project(self, project_dir: str):
         await self._send(MessageType.IMPORT_PROJECT, content={"project_dir": project_dir})
 
+    async def prompt_for_directory_path(self) -> str:
+        user_input = await self.ask_question(
+            "Please enter the directory path for the newly imported project:",
+            allow_empty=False,
+        )
+        return user_input.text
+
 
 __all__ = ["IPCClientUI"]


### PR DESCRIPTION
 entered directory path.

* **core/cli/helpers.py**: 
  - Add `Add-- functionalitydirectory to-path prompt` for command directory-line path argument for.
 newly  imported - project Update.

 `*load **_configcore`/ functionagents to/import handleer the.py new** command:
-line  argument -.

 Add* ` **promptcore_for/_directorycli_path/main`.py method** to: prompt 
 the  user - for Update the ` directoryrun path_p.
yth ag -ora Update_session ``start function_import to_process handle` the method new to command use-line the argument entered.

 directory* path **.

core*/ui **/basecore.py/**cli:/helpers 
.py ** -:
 Add  ` -prompt Add_for `_directory--_pathdirectory`-path method` to command prompt-line the argument user.
 for  the - directory Update path `.

load*_config **`core function/ui to/ip handlec the_client new.py command**-line: argument 
.

 * - ** Implementcore `/promptcli_for/main_directory.py_path**`:
 method  to - prompt Update the ` userrun for_p theyth directoryag pathora.

_session` function to handle the new command-line argument.

* **core/ui/base.py**:
  - Add `prompt_for_directory_path` method to
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Thetruemank/gpt-pilot?shareId=cbe1e842-a7b9-4dd6-80dd-49416bdf9a92). prompt the user for the directory path.

* **core/ui/ipc_client.py**:
  - Implement `prompt_for_directory_path` method to prompt the user for the directory path.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Thetruemank/gpt-pilot?shareId=bc76a2db-90bf-4558-91f0-8f75d925a19b).